### PR TITLE
Add method to validate JSON as a string

### DIFF
--- a/lib/sloth/string_helpers.rb
+++ b/lib/sloth/string_helpers.rb
@@ -3,5 +3,13 @@ module Sloth
     def email?
       (self =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i) == 0
     end
+
+    def json?
+      begin 
+        return true if JSON.parse(self)
+      rescue JSON::ParserError => e
+        return false
+      end
+    end
   end
 end

--- a/spec/string_helpers_spec.rb
+++ b/spec/string_helpers_spec.rb
@@ -16,5 +16,21 @@ describe Sloth do
         expect(invalid_email.email?).to be_falsy
       end
     end
+
+    describe "''.json?" do
+      it "returns true for valid json" do
+        valid_jsons = ['{"1": 1, "2": 2, "3": {"4": 4, "5": {"6": 6}}}',  '{"1": 1}', '{}']
+        valid_jsons.each do |valid_json|
+          expect(valid_json).to be_json
+        end
+      end
+
+      it "returns false for invalid json" do
+        invalid_jsons = ['{"1": 1, "2": 2, "3": {"4": 4, "5": {"6": 6}', '{"1" 1}', '']
+        invalid_jsons.each do |invalid_json|
+          expect(invalid_json).not_to be_json
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The new method added to StringHelpers checks if a String to be in a valid JSON format or not.
